### PR TITLE
Support multiple instances of configs

### DIFF
--- a/src/layout/inputs.html
+++ b/src/layout/inputs.html
@@ -1,5 +1,5 @@
 <script type="text/ng-template" id="wgn-config-inputs">
-	<div ng-if="!settings.multi || (settings.multi && editing.config.name && !wgnConfigForm.$error.configName)">
+	<div ng-if="!settings.multi || (settings.multi && editing.config.name && !editing.form.$error.configName)">
 		<div ng-if="settings.pages.length === 1" class="single-page">
 			<wgn-config-page specs="settings.pages[0]"></wgn-config-page>
 		</div>

--- a/src/layout/name.html
+++ b/src/layout/name.html
@@ -10,7 +10,7 @@
 
 			<span class="help-block">Specify a unique name for this configuration.</span>
 
-			<span class="help-block danger" ng-show="wgnConfigForm.$error.configName">
+			<span class="help-block danger" ng-show="editing.form.$error.configName">
 				The config name must be unique
 			</span>
 		</div>

--- a/src/main.controller.js
+++ b/src/main.controller.js
@@ -32,7 +32,10 @@ plugin.controller('wgnConfigCtrl', ['$scope', '$q', '$routeParams', 'znData', 'z
 		 *
 		 * @type {Object<Object|boolean>}
 		 */
-		$scope.editing = { config: false };
+		$scope.editing = {
+			config: false,
+			form: null
+		};
 
 		/**
 		 * The current display mode, one of 'grid' or 'list'.
@@ -59,7 +62,7 @@ plugin.controller('wgnConfigCtrl', ['$scope', '$q', '$routeParams', 'znData', 'z
 
 				doRunHook('add', $scope.editing.config).finally(function () {
 					doResetTab();
-					$scope.wgnConfigForm.$setPristine();
+					$scope.editing.form.$setPristine();
 				});
 			});
 		};
@@ -79,7 +82,7 @@ plugin.controller('wgnConfigCtrl', ['$scope', '$q', '$routeParams', 'znData', 'z
 
 				doRunHook('edit', $scope.editing.config).finally(function () {
 					doResetTab();
-					$scope.wgnConfigForm.$setPristine();
+					$scope.editing.form.$setPristine();
 				});
 			});
 		};
@@ -155,7 +158,7 @@ plugin.controller('wgnConfigCtrl', ['$scope', '$q', '$routeParams', 'znData', 'z
 						doDiscardChanges();
 					} else {
 						doResetTab();
-						$scope.wgnConfigForm.$setPristine();
+						$scope.editing.form.$setPristine();
 					}
 
 					znMessage('Configuration saved!', 'saved');
@@ -215,7 +218,7 @@ plugin.controller('wgnConfigCtrl', ['$scope', '$q', '$routeParams', 'znData', 'z
 			var def = $q.defer();
 
 			// Only prompt if form has been changed.
-			if (!$scope.wgnConfigForm.$dirty) {
+			if (!$scope.editing.form.$dirty) {
 				doDiscardChanges();
 				return $q.when(true);
 			}
@@ -567,7 +570,7 @@ plugin.controller('wgnConfigCtrl', ['$scope', '$q', '$routeParams', 'znData', 'z
 				angular.extend($scope.editing.config, _originalConfig);
 			}
 
-			$scope.wgnConfigForm.$setPristine();
+			$scope.editing.form.$setPristine();
 		}
 
 		/**

--- a/src/main.html
+++ b/src/main.html
@@ -14,10 +14,10 @@
 
 		<span ng-show="loading" class="throbber"></span>
 
-		<div class="config-container" ng-hide="loading">
+		<div class="config-container" ng-if="!loading">
 			<wgn-config-list ng-show="!editing.config && settings.multi"></wgn-config-list>
 
-			<form class="form" name="wgnConfigForm" ng-submit="onSaveConfig()" ng-show="editing.config" novalidate>
+			<form class="form" name="editing.form" ng-submit="onSaveConfig()" ng-show="editing.config" novalidate>
 				<a href="javascript:" ng-click="onDiscardChanges()" ng-show="settings.multi">
 					<i class="icon icon-left-circled"></i> Back
 				</a>
@@ -26,7 +26,7 @@
 					<div class="form-actions">
 						<button type="button" class="btn btn-success pull-right" ng-click="onEnableConfig()"
 								ng-show="settings.toggle && editing.config.$id && !editing.config.enabled"
-								ng-disabled="wgnConfigForm.$invalid || saving">
+								ng-disabled="editing.form.$invalid || saving">
 							Enable
 						</button>
 
@@ -50,17 +50,17 @@
 
 				<div class="form-actions bottom-actions">
 					<button type="submit" class="btn btn-primary pull-right"
-							ng-disabled="!wgnConfigForm.$dirty || wgnConfigForm.$invalid || saving">
+							ng-disabled="!editing.form.$dirty || editing.form.$invalid || saving">
 						Save configuration
 					</button>
 
 					<button type="button" class="btn pull-right" ng-click="onDiscardChanges()"
-							ng-show="settings.multi || wgnConfigForm.$dirty">
+							ng-show="settings.multi || editing.form.$dirty">
 						<span ng-show="settings.multi">Cancel</span>
 						<span ng-hide="settings.multi">Discard changes</span>
 					</button>
 
-					<div class="required-fields pull-right" ng-show="!wgnConfigForm.$pristine && wgnConfigForm.$error.required">
+					<div class="required-fields pull-right" ng-show="!editing.form.$pristine && editing.form.$error.required">
 						Please fill all required fields
 					</div>
 				</div>


### PR DESCRIPTION
@alexweber with these fixes, we can do global configs pretty easily by including the config directive twice in the settings page: one single config and one multi config. props to @tehpsalmist for the idea
