### PR TITLE
fix: populate dropdown w/ existing values

### DIFF
--- a/src/inputs/choice.html
+++ b/src/inputs/choice.html
@@ -1,12 +1,13 @@
 <!--Choice input (this is a complex one, read the docs if confused!)-->
 <script type="text/ng-template" id="wgn-config-input-choice">
-	<div>
+	<div ng-controller="wgnFieldInputCntrl">
 		<select class="form-control" name="input"
 				ng-model="editing.config[field.id + '_source']"
-				ng-options="f.id as f|formFieldTitle for f in getFields(field, specs)"
+				ng-options="f.id as f|formFieldTitle for f in fieldValues"
 				ng-disabled="isFieldLoading(field.belongsTo) || !editing.config[field.belongsTo]"
 				ng-change="resetChoiceValues(field.id)"
-				ng-required="field.required">
+				ng-required="field.required"
+				ng-focus="fieldValues = getFields(field, specs)">
 			<option value=""></option>
 		</select>
 

--- a/src/inputs/field.html
+++ b/src/inputs/field.html
@@ -1,16 +1,15 @@
 <!--Field picker input-->
 <script type="text/ng-template" id="wgn-config-input-field">
-	<div>
+	<div ng-controller="wgnFieldInputCntrl">
 		<select class="form-control" name="input"
-				ng-init="fieldValues = []"
 				ng-model="editing.config[field.id]"
 				ng-options="f.id as f|formFieldTitle for f in fieldValues"
-				ng-disabled="isFieldLoading(field.belongsTo) || !editing.config[field.belongsTo]"
+				ng-disabled="!loaded || !editing.config[field.belongsTo]"
 				ng-required="field.required"
 				ng-focus="fieldValues = getFields(field, specs)">
 			<option value=""></option>
 		</select>
 
-		<span ng-show="isFieldLoading(field.belongsTo)" class="throbber inline throbber"></span>
+		<span ng-show="!loaded" class="throbber inline throbber"></span>
 	</div>
 </script>

--- a/src/inputs/fieldInput.controller.js
+++ b/src/inputs/fieldInput.controller.js
@@ -1,0 +1,18 @@
+plugin.controller('wgnFieldInputCntrl', ['$scope', function ($scope) {
+
+	function setFieldValues() {
+		$scope.fieldValues = $scope.getFields($scope.field, $scope.specs);
+	}
+
+	var unWatch = $scope.$watch('formLoaded[editing.config[field.belongsTo]]', function (loaded) {
+
+		$scope.loaded = loaded;
+
+		if (loaded) {
+			setFieldValues();
+			unWatch();
+		}
+	});
+
+	$scope.$watch('editing.config[field.belongsTo]', setFieldValues);
+}]);

--- a/src/inputs/folder.html
+++ b/src/inputs/folder.html
@@ -1,16 +1,15 @@
 <!--Folder picker input-->
 <script type="text/ng-template" id="wgn-config-input-folder">
-	<div>
+	<div ng-controller="wgnFolderInputCntrl">
 		<select class="form-control" name="input"
-				ng-init="folderValues = []"
 				ng-model="editing.config[field.id]"
 				ng-options="f.id as f.name for f in folderValues"
-				ng-disabled="isFolderLoading(field.belongsTo) || !editing.config[field.belongsTo]"
+				ng-disabled="!loaded || !editing.config[field.belongsTo]"
 				ng-required="field.required"
 				ng-focus="folderValues = getFolders(field, specs)">
 			<option value=""></option>
 		</select>
 
-		<span ng-show="isFolderLoading(field.belongsTo)" class="throbber inline throbber"></span>
+		<span ng-show="!loaded" class="throbber inline throbber"></span>
 	</div>
 </script>

--- a/src/inputs/folderInput.controller.js
+++ b/src/inputs/folderInput.controller.js
@@ -1,0 +1,18 @@
+plugin.controller('wgnFolderInputCntrl', ['$scope', function ($scope) {
+
+	function setFolderValues() {
+		$scope.folderValues = $scope.getFolders($scope.field, $scope.specs);
+	}
+
+	var unWatch = $scope.$watch('formLoaded[editing.config[field.belongsTo]]', function (loaded) {
+
+		$scope.loaded = loaded;
+
+		if (loaded) {
+			setFolderValues();
+			unWatch();
+		}
+	});
+
+	$scope.$watch('editing.config[field.belongsTo]', setFolderValues);
+}]);

--- a/src/inputs/form.html
+++ b/src/inputs/form.html
@@ -1,16 +1,15 @@
 <!--Form picker input-->
 <script type="text/ng-template" id="wgn-config-input-form">
-	<div>
+	<div ng-controller="wgnFormInputCntrl">
 		<select class="form-control" name="input"
 				ng-options="form.id as form.name for form in formValues"
 				ng-model="editing.config[field.id]"
-				ng-init="formValues = []"
-				ng-disabled="field.belongsTo && (isFormLoading(field.belongsTo) || !editing.config[field.belongsTo])"
+				ng-disabled="field.belongsTo && (!loaded || !editing.config[field.belongsTo])"
 				ng-required="field.required"
 				ng-focus="formValues = getForms(field, editing.config[field.belongsTo])">
 			<option value=""></option>
 		</select>
 
-		<span ng-show="field.belongsTo && isFormLoading(field.belongsTo)" class="throbber inline throbber"></span>
+		<span ng-show="!loaded" class="throbber inline throbber"></span>
 	</div>
 </script>

--- a/src/inputs/formInput.controller.js
+++ b/src/inputs/formInput.controller.js
@@ -1,0 +1,18 @@
+plugin.controller('wgnFormInputCntrl', ['$scope', function ($scope) {
+
+	function setFormValues() {
+		$scope.formValues = $scope.getForms($scope.field, $scope.editing.config[$scope.field.belongsTo]);
+	}
+
+	var unWatch = $scope.$watch('workspaceLoaded[editing.config[field.belongsTo]]', function (loaded) {
+
+		$scope.loaded = loaded;
+
+		if (loaded) {
+			setFormValues();
+			unWatch();
+		}
+	});
+
+	$scope.$watch('editing.config[field.belongsTo]', setFormValues);
+}]);

--- a/src/inputs/workspace.html
+++ b/src/inputs/workspace.html
@@ -4,7 +4,7 @@
 			ng-options="ws.id as ws.name for ws in wsValues"
 			ng-model="editing.config[field.id]"
 			ng-change="onSelectWorkspace(field.id)"
-			ng-init="initWorkspaceInput(field.id); wsValues = []"
+			ng-init="initWorkspaceInput(field.id); wsValues = getWorkspaces(field)"
 			ng-required="field.required"
 			ng-focus="wsValues = getWorkspaces(field)">
 		<option value=""></option>

--- a/src/main.controller.js
+++ b/src/main.controller.js
@@ -7,9 +7,6 @@ plugin.controller('wgnConfigCtrl', ['$scope', '$q', '$routeParams', 'znData', 'z
 		var _forms = {};
 		var _fields = {};
 		var _folders = {};
-		var _formsLoading = {};
-		var _fieldsLoading = {};
-		var _foldersLoading = {};
 		var _originalConfig;
 		var _webhook = false;
 
@@ -19,6 +16,21 @@ plugin.controller('wgnConfigCtrl', ['$scope', '$q', '$routeParams', 'znData', 'z
 		 * @type {boolean}
 		 */
 		$scope.loading = true;
+
+
+		/**
+		 * Whether the workspace has loaded
+		 *
+		 * @type {Object<boolean>}
+		 */
+		$scope.workspaceLoaded = {};
+
+		/**
+		 * Whether the form has loaded
+		 *
+		 * @type {Object<boolean>}
+		 */
+		$scope.formLoaded = {};
 
 		/**
 		 * Whether the plugin is saving or not, displays a throbber.
@@ -431,32 +443,6 @@ plugin.controller('wgnConfigCtrl', ['$scope', '$q', '$routeParams', 'znData', 'z
 		};
 
 		/**
-		 * Returns whether a given form is loading its fields.
-		 *
-		 * @param {string} key A form config id.
-		 *
-		 * @return {boolean}
-		 */
-		$scope.isFieldLoading = function (key) {
-			if ($scope.editing.config && key in $scope.editing.config) {
-				return $scope.editing.config[key] in _fieldsLoading ? _fieldsLoading[$scope.editing.config[key]] : false;
-			}
-		};
-
-		/**
-		 * Returns whether a given form is loading its folders.
-		 *
-		 * @param {string} key A form config id.
-		 *
-		 * @return {boolean}
-		 */
-		$scope.isFolderLoading = function (key) {
-			if ($scope.editing.config && key in $scope.editing.config) {
-				return $scope.editing.config[key] in _foldersLoading ? _foldersLoading[$scope.editing.config[key]] : false;
-			}
-		};
-
-		/**
 		 * Saves after a configuration toggle.
 		 *
 		 * @param {Object} config
@@ -564,7 +550,7 @@ plugin.controller('wgnConfigCtrl', ['$scope', '$q', '$routeParams', 'znData', 'z
 		 * @param {number} workspaceId
 		 */
 		function loadForms (workspaceId) {
-			_formsLoading[workspaceId] = true;
+
 
 			return znData('Forms').get({ 'workspace.id': workspaceId, 'limit': 200, 'related': 'fields,folders' }).then(function (forms) {
 				_forms[workspaceId] = forms;
@@ -594,11 +580,13 @@ plugin.controller('wgnConfigCtrl', ['$scope', '$q', '$routeParams', 'znData', 'z
 							name: folder.name
 						});
 					});
+
+					$scope.formLoaded[form.id] = true;
 				});
 			}).catch(function (err) {
 				znMessage(err, 'error');
 			}).finally(function () {
-				_formsLoading[workspaceId] = false;
+				$scope.workspaceLoaded[workspaceId] = true;
 			});
 		}
 


### PR DESCRIPTION
- when existing config had a workspace field, the existing field, folder, and form values
 weren't populating the dropdowns. Keep getFields/getFolders methods out of ng-repeat, but in addition to onFocus, make sure it's
 called after form has been loaded and whenever the form changes.
- also fixes regression with throbber not showing  while loading