### PR TITLE
feat: enable beforeSave hook

### DIFF
--- a/src/main.controller.js
+++ b/src/main.controller.js
@@ -155,34 +155,37 @@ plugin.controller('wgnConfigCtrl', ['$scope', '$q', '$routeParams', 'znData', 'z
 			}
 
 			removeHiddenValues();
-
-			return doSaveConfig($scope.editing.config).then(function () {
-				if ($scope.settings.toggle && !$scope.editing.config.enabled && !('$id' in $scope.editing.config)) {
-					znModal({
-						title: '',
-						template: '<p>Your new configuration was saved!</p><p>It must be manually enabled to be active.</p>',
-						classes: 'config-enable-message',
-						closeButton: false,
-						btns: {
-							'OK': {
-								primary: true
+			return doRunHook('beforeSave', $scope.editing.config).finally(function () {
+				return doSaveConfig($scope.editing.config).then(function () {
+					if ($scope.settings.toggle && !$scope.editing.config.enabled && !('$id' in $scope.editing.config)) {
+						znModal({
+							title: '',
+							template: '<p>Your new configuration was saved!</p><p>It must be manually enabled to be active.</p>',
+							classes: 'config-enable-message',
+							closeButton: false,
+							btns: {
+								'OK': {
+									primary: true
+								}
 							}
-						}
-					});
-				}
-
-				return doRunHook('save', $scope.editing.config).finally(function () {
-
-					if ($scope.settings.multi) {
-						doDiscardChanges();
-					} else {
-						doResetTab();
-						$scope.editing.form.$setPristine();
+						});
 					}
 
-					znMessage('Configuration saved!', 'saved');
-					$scope.saving = false;
+					return doRunHook('save', $scope.editing.config).finally(function () {
+
+						if ($scope.settings.multi) {
+							doDiscardChanges();
+						} else {
+							doResetTab();
+							$scope.editing.form.$setPristine();
+						}
+
+						znMessage('Configuration saved!', 'saved');
+						$scope.saving = false;
+					});
 				});
+			}).catch(function () {
+				znMessage('There was an error saving the configuration!', 'error');
 			});
 		};
 

--- a/src/main.controller.js
+++ b/src/main.controller.js
@@ -155,6 +155,7 @@ plugin.controller('wgnConfigCtrl', ['$scope', '$q', '$routeParams', 'znData', 'z
 			}
 
 			removeHiddenValues();
+			
 			return doRunHook('beforeSave', $scope.editing.config).finally(function () {
 				return doSaveConfig($scope.editing.config).then(function () {
 					if ($scope.settings.toggle && !$scope.editing.config.enabled && !('$id' in $scope.editing.config)) {

--- a/src/settings.service.js
+++ b/src/settings.service.js
@@ -308,6 +308,7 @@ plugin.service('wgnConfigSettings', ['$q', 'wgnConfigInputs', function ($q, conf
 				'disable',
 				'discard',
 				'init',
+				'beforeSave',
 				'save'
 			];
 


### PR DESCRIPTION
Need some other eyes on adding a beforeSave event.

Anna's note.  Functionally what do we want? Should a rejection in the beforeSave prevent a save?
or should it save regardless of a rejection/fulfillment.

I did it with finally to be consistent with other [cases](https://github.com/ZengineHQ/zn-frontend-config/blob/37d8df7c3c962be085450ba65386dd51581804a0/src/main.controller.js#L223) where we do actions (enable, disable). 

[](url)