### PR TITLE
Hotfix/change webhook form

### DIFF
--- a/src/main.html
+++ b/src/main.html
@@ -26,18 +26,18 @@
 					<div class="form-actions">
 						<button type="button" class="btn btn-success pull-right" ng-click="onEnableConfig()"
 								ng-show="settings.toggle && editing.config.$id && !editing.config.enabled"
-								ng-disabled="editing.form.$invalid || saving">
+								ng-disabled="editing.form.$dirty || editing.form.$invalid || saving">
 							Enable
 						</button>
 
 						<button type="button" class="btn btn-warning pull-right" ng-click="onDisableConfig()"
-								ng-disabled="saving"
+								ng-disabled="editing.form.$dirty || saving"
 								ng-show="settings.toggle && editing.config.$id && editing.config.enabled">
 							Disable
 						</button>
 
 						<button type="button" class="btn btn-danger pull-right" ng-click="onDeleteConfig()"
-								ng-disabled="saving"
+								ng-disabled="editing.form.$dirty || saving"
 								ng-show="settings.multi && editing.config.$id">
 							Delete
 						</button>


### PR DESCRIPTION
- Delete existing webhook on saving changes. This creates a new webhook with the updated form ID.
- Also disabled ability to enable webhook when the form is in edit mode.